### PR TITLE
Fix calculation of the lost HP when unit level up

### DIFF
--- a/Board.lua
+++ b/Board.lua
@@ -341,7 +341,7 @@ function Board:getTotalLostHP(isWin)
     for i = _start, _end do
         if self.units[i] and self.units[i].isAutoTroop == false then
             if self.units[i].isWinLvlUp then
-                restHP = restHP + self.units[i].maxHealth
+                restHP = restHP + self.units[i].initalHealth
             elseif self:isUnitAlive(i) then
                 restHP = restHP + self.units[i].currentHealth
             end

--- a/Unit.lua
+++ b/Unit.lua
@@ -20,6 +20,7 @@ function Unit:new(blizzardUnitInfo)
         followerGUID = blizzardUnitInfo.followerGUID,
         name = blizzardUnitInfo.name,
         maxHealth = blizzardUnitInfo.maxHealth,
+        initalHealth = blizzardUnitInfo.health,
         currentHealth = blizzardUnitInfo.health,
         attack = blizzardUnitInfo.attack,
         isAutoTroop = blizzardUnitInfo.isAutoTroop,


### PR DESCRIPTION
Fix the calculation of the lost HP when unit level up but starts the mission with non full health.